### PR TITLE
Use Updated Lives, Update

### DIFF
--- a/src/data/releases.json
+++ b/src/data/releases.json
@@ -1,29 +1,28 @@
 [
-## "TODO": "Update SHA256|512sums, GA releaseDate, size values",
     {
 	"arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-WORK-x86_64-20171005.iso",
         "releaseDate": "20171005",
 	"sha512": :"af22e38f3ce74dda3fc4a784e2bb3a19179ea2413de18d4e16f2a6f9e4d2781c27191693ec22ad206d35dd7688d704e2c8557519bea1e2b6f85a5f956f504855",
-	"size":"",
+	"size":"1737490432",
 	"subvariant": "WORK-latest",
         "version": "26"
     },
     {
         "arch": "x86_64",
         "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Server/x86_64/iso/Fedora-Server-dvd-x86_64-26-1.5.iso",
-        "releaseDate": "",
-	"sha256": "",
-	"size":" ",
+        "releaseDate": "20170707",
+	"sha256": "fad18a43b9cec152fc8a1fd368950eaf59be66b1a15438149a0c3a509c56cf2f",
+	"size":"2401239040",
 	"subvariant": "Server-traditional",
         "version": "26"
     },
     {
         "arch": "x86_64",
         "link": "https://download.fedoraproject.org/pub/alt/releases/26/Labs/x86_64/iso/Fedora-Python-Classroom-Live-x86_64-26-1.5.iso",
-        "releaseDate": "",
-	"sha256": "",
-	"size": "",
+        "releaseDate": "20170705",
+	"sha256": "cc31eff029ff4e80f1c1cfb4885f108be7e359fa5179a7b14fdd85291a48fb6a",
+	"size": "1482686464",
 	"subvariant": "python-classroom",
         "version": "26"
     },
@@ -32,7 +31,7 @@
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-KDE-x86_64-20170927.iso",
         "releaseDate": "20170927",
 	"sha512": "d2ba1dd9960fddb950da54756df2f4744d884bb88af26066c0456b5d2a080e8eb415868e82a78533ba8aa165b726d321738fca3164fd7dc8c690b06b315865d3",
-	"size":"",
+	"size":"1507852288",
 	"subvariant": "KDE-latest",
         "version": "26",
 	"note":"Failed to build 20171005"
@@ -40,9 +39,9 @@
     {
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-XFCE-x86_64-20171005.iso",
-        "releaseDate": "",
+        "releaseDate": "20171005",
 	"sha512": "00b23af417ec1892a9d48a32dbfd12b848dfcbf1888636f849ec6a2ce419417d2a0337e8048885253a8dc12bd456e41aeb8bd28dede9c9ff60b12c4e40871415",
-	"size": "",
+	"size": "1373634560",
 	"subvariant": "XFCE-latest",
         "version": "26"
     },
@@ -51,7 +50,7 @@
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-MATE-x86_64-20170927.iso",
         "releaseDate": "",
 	"sha512": "91c24c654ba202ed7d22a057ea088d50a31752f1500a30806897a2ed705ac476e472c81f05f7c72f9e47b3671eebda0743d958bcbab6d8a612324b1b893e6580",
-	"size":"",
+	"size":"1647312896",
 	"subvariant": "MATE-latest",
         "version": "26",
 	"note": "Failed to build 20171005"
@@ -61,7 +60,7 @@
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-LXDE-x86_64-20171005.iso",
         "releaseDate": "20171005".
 	"sha512":"687f9d07fc7a6af79c9a796c283bea2367b2d0fbdfd1521144a1272a2c650f6382ddbaff979412621693e662e24cd82bf68b34370e04f718b5c52c9e6922907b",
-	"size":"",
+	"size":"1048576000",
 	"subvariant": "LXDE-latest",
         "version": "26"
      },
@@ -69,9 +68,18 @@
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-LXQT-x86_64-20171005.iso",
        	"releaseDate": "20171005",
-	"sha512": "",
+	"sha512": "930a2ccadc839fbc649d6115c577c4f106c0c8dc515dbc431c10431d538e591ae0f1ec1b980e9248469b9025954ef591f86e55d14959fd4b06cf174aabb69a0c",
 	"size":"930a2ccadc839fbc649d6115c577c4f106c0c8dc515dbc431c10431d538e591ae0f1ec1b980e9248469b9025954ef591f86e55d14959fd4b06cf174aabb69a0c",
 	"subvariant": "LXQT-latest",
+        "version": "26"
+    },
+    {
+        "arch": "x86_64",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-SOAS-x86_64-20171005.iso",
+        "releaseDate": "20171005",
+        "sha512": "1ae9d432a5afd3028f459bd704695232aff4c139d3f807ed029506b4b939ce98a932ffc49761bfd4bbc11a3570f0813426398a8729f9a106631286a4e3662b64",
+        "size": "900726784",
+        "subvariant": "SOAS-latest",
         "version": "26"
     },
     {
@@ -79,7 +87,7 @@
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-CINN-x86_64-20171005.iso",
         "releaseDate": "20171005",
         "sha512": "da82ecf0b9466ecb1392f341182359872c46a95064df921110eac06a0e507c4b1ef6e554d6b0585a097511bbe964f5a966c5227e7981fddec8bc55958cf4e2e9",
-	"size": "",
+	"size": "1535115264",
 	"subvariant": "CINN-latest",
         "version": "26"
     },
@@ -95,59 +103,47 @@
     {
         "arch": "x86_64",
         "link": "https://dl.fedoraproject.org/pub/alt/releases/26/Labs/x86_64/iso/Fedora-Astronomy_KDE-Live-x86_64-26-1.5.iso",
-        "releaseDate": "",
-	"sha256": "" ,
-	"size": "",
+        "releaseDate": "20170707",
+	"sha256": "70a9a4447db6473cad73065d42cadd6d4460fbd1a487f6d2a17a4c39708b94fb" ,
+	"size": "2668625920",
 	"subvariant": "Astronomy",
         "version": "26"
     },
     {
-## "TODO":"Update for KDE_JAM",
 	"arch": "x86_64", 
-	"link":"",
-	"releaseDate":"",
-	"sha256":"",
-	"size":"",
-	"subvariant": "KDE-Jam",
+	"link":"https://download-ib01.fedoraproject.org/pub/alt/releases/26/Labs/x86_64/iso/Fedora-Robotics-Live-x86_64-26-1.5.iso",
+	"releaseDate":"20170707",
+	"sha256":"e458747d2df50fb7db91393c849d032a80ec0e3a3f8652b550cf1a8b94be857e",
+	"size":"2552233984",
+	"subvariant": "Robotics",
         "version": "26"
     },
     {
-## "TODO":"Update for Security Spin",
         "arch": "x86_64",
-        "link": "",
-        "releaseDate": "",
-        "sha256": "",
-        "size": "",
+        "link": "https://download-ib01.fedoraproject.org/pub/alt/releases/26/Labs/x86_64/iso/Fedora-Security-Live-x86_64-26-1.5.iso",
+        "releaseDate": "20170707",
+        "sha256": "55f4bb83f36a8963e8f0a7fb31107f4ce97b5c9c8716101a36038bd17728d2d1",
+        "size": "1245708288",
         "subvariant": "SecurityLab",
         "version": "26"
     },
     {
-## "TODO":"Update for Design_Suite",
         "arch": "x86_64",
-        "link": "",
-        "releaseDate": "",
-        "sha256": "",
-        "size": "",
+        "link": "https://download-ib01.fedoraproject.org/pub/alt/releases/26/Labs/x86_64/iso/Fedora-Design_suite-Live-x86_64-26-1.5.iso",
+        "releaseDate": "20170707",
+        "sha256": "12d67c6e579854fe5e211e6543ac551f186f59bee866bfa51222e9a4b86a5ec1",
+        "size": "2139095040",
         "subvariant": "Design_Suite",
         "version": "26"
     },
     {
+
         "arch": "x86_64",
-        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-SOAS-x86_64-20171005.iso",
-        "releaseDate": "20171005",
-        "sha256": "",
-        "size": "",
-        "subvariant": "SOAS",
-        "version": "26"
-    },
-    {
-## "TODO":"Update for Scientific_KDE",
-        "arch": "x86_64",
-        "link": "",
-        "releaseDate": "",
-        "sha256": "",
-        "size": "",
+        "link": "https://download-ib01.fedoraproject.org/pub/alt/releases/26/Labs/x86_64/iso/Fedora-Games-Live-x86_64-26-1.5.iso",
+        "releaseDate": "20170707",
+        "sha256": "300f97fe6d946d04e8ff92c1d7cc7d80e7365cfb62cdee3da8604bf1531f358c",
+        "size": "4129292288",
 	"subvariant": "Scientific_KDE",
         "version": "26"
-    },
+   }
 ]

--- a/src/data/releases.json
+++ b/src/data/releases.json
@@ -1,7 +1,7 @@
 [
     {
         "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-26-1.5.iso",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-WORK-x86_64-20170927.iso",
         "subvariant": "Workstation",
         "version": "26"
     },
@@ -19,287 +19,81 @@
     },
     {
         "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Spins/x86_64/iso/Fedora-KDE-Live-x86_64-26-1.5.iso",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-KDE-x86_64-20170927.iso",
         "subvariant": "KDE",
         "version": "26"
     },
     {
         "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Spins/x86_64/iso/Fedora-Xfce-Live-x86_64-26-1.5.iso",
-        "subvariant": "xfce",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-XFCE-x86_64-20170927.iso",
+        "subvariant": "XFCE",
         "version": "26"
     },
     {
-        "arch": "i386",
-        "link": "http://www.freedos.org/freedos/files/download/fd11src.iso",
-        "releaseDate": "",
-        "sha256": "10190ff0d38f0d523f748504d5165fa5437492f42887ed8e3cfdad32781147b7",
-        "size": "40828928",
-        "subvariant": "freedos",
-        "version": "1.1"
-    },
-    {
         "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "818017f42a2741cfaf20e94aecf6a63d1b995abfdaff5917df7218d0d89976a7",
-        "size": "1440743424",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-WORK-x86_64-20170927.iso",
+        "releaseDate": "2017-09-29",
+        "sha512": "c7ce66fb93abbf4987e71bb4b7783dffb696098af539c588594e8952ff251a653895936621ffa615211ca693a89d493bc7622e9ce65c18da4b4cf2c1f34feb56",
+        "size": "1500512256",
         "subvariant": "Workstation",
-        "version": "25"
+        "version": "26"
     },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Workstation/x86_64/iso/Fedora-Workstation-netinst-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "6a1e69416b0d72efd2962ce01bdad547074a32b70f7d70e2e6436d16398522a7",
-        "size": "486539264",
-        "subvariant": "Workstation",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Workstation/i386/iso/Fedora-Workstation-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "da4a07c6758070f9ada0458664436e5d4a8bc19a0480c8dd03ccf9afd21b5fef",
-        "size": "1529872384",
-        "subvariant": "Workstation",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Workstation/i386/iso/Fedora-Workstation-netinst-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "5be31b8a3f7158c9dc2a72be2032331e7d84227d71a03134b57861c9b058e86e",
-        "size": "545259520",
-        "subvariant": "Workstation",
-        "version": "25"
-    },
-    {
-        "arch": "armhfp",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Workstation/armhfp/images/Fedora-Workstation-armhfp-25-1.3-sda.raw.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "553885d5643de06c468997f0e6a0bc1f1ba759d5ed806ac4d3f115522dfd6fbf",
-        "size": "1253551936",
-        "subvariant": "Workstation",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Cloud/x86_64/iso/Fedora-Cloud-netinst-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "4d3413ed81e89baf79efa4c0217ad652967699b5072147ae3eeef7e075e3723d",
-        "size": "503316480",
-        "subvariant": "Cloud",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Cloud/i386/iso/Fedora-Cloud-netinst-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "4935e1e2b3e516152809d22d6c0865a8e976a594c207e72152b7c8e5955929fa",
-        "size": "510656512",
-        "subvariant": "Cloud",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Server/x86_64/iso/Fedora-Server-dvd-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "524bd959dae09ad6fc8e0476ea478700d89f82ec5795d0b1a7b873613f3f26ac",
-        "size": "2018508800",
-        "subvariant": "Server",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Server/x86_64/iso/Fedora-Server-netinst-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "86bc3694f4938382753d1e9536f2140a6c9c1978207766340c679a89509073c7",
-        "size": "507510784",
-        "subvariant": "Server",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Server/i386/iso/Fedora-Server-dvd-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "888ce3dd791854c8e0f62e9eac292a90cf9765a3f2de75b6ceb99eaa62d7f2cc",
-        "size": "2113929216",
-        "subvariant": "Server",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Server/i386/iso/Fedora-Server-netinst-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "92b021a101a92d40d8705064cd9bc68468678d72d0c7779fe006fff75d54c2f1",
-        "size": "489684992",
-        "subvariant": "Server",
-        "version": "25"
-    },
-    {
-        "arch": "armhfp",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Server/armhfp/images/Fedora-Server-armhfp-25-1.3-sda.raw.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "6b1cc2636693be097f61a17863e6979a50f789910593e67bbb9ed81fe83899d4",
-        "size": "589296624",
-        "subvariant": "Server",
-        "version": "25"
-    },
-    {
-        "arch": "armhfp",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Server/armhfp/iso/Fedora-Server-dvd-armhfp-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "0e1a94029b3bf5ff2e8274c20543cd4354dd8bbdea0a074ca310fccad5afd432",
-        "size": "1838303232",
-        "subvariant": "Server",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/x86_64/iso/Fedora-Astronomy_KDE-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "d5244d2f4cc2a1cb8e83477b931f40a68f82c98f97682874db3822d3f5e53628",
-        "size": "2542796800",
-        "subvariant": "Astronomy_KDE",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/x86_64/iso/Fedora-Design_suite-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "91e691c6ede78868f0729dc938c3fc24d314a57a5a3424976f551f28dee82c86",
-        "size": "2204106752",
-        "subvariant": "Design_suite",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/x86_64/iso/Fedora-Games-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "204ff15311bb49d91c87781a7f58d06d002bef27afaf4d1e8c49e20d7bf12424",
-        "size": "4028628992",
-        "subvariant": "Games",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/x86_64/iso/Fedora-Jam_KDE-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "aafea68c17e0475e3499450d3c311df93f283c9acefbabde8318f1aae0d7f0a7",
-        "size": "2080374784",
-        "subvariant": "Jam_KDE",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/x86_64/iso/Fedora-Robotics-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "6f54f18d64662b6d64e97e1059e2283e0030522ca46956e4f36bb332cf4c081d",
-        "size": "2357198848",
-        "subvariant": "Robotics",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/x86_64/iso/Fedora-Scientific_KDE-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "5bd224eca68e713053e0da1452fbd92df38de917bb7bdb223f4b38df96a1a159",
-        "size": "3107979264",
-        "subvariant": "Scientific_KDE",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/x86_64/iso/Fedora-Security-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "c01c6705f52dd8c8657c5f5c0ff79e94ee37a22d819bffd2569c420a14edfa4b",
-        "size": "1158676480",
-        "subvariant": "Security",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/i386/iso/Fedora-Astronomy_KDE-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "62b5e7cf09c723c9c8aded369e9209c860b2ce7bf85c16513e308e02b8ae8487",
-        "size": "2642411520",
-        "subvariant": "Astronomy_KDE",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/i386/iso/Fedora-Design_suite-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "1217a67f05ccf7dc51864db97ce0a1af55d0c5e5a6209029c4504bab5d2937c1",
-        "size": "2285895680",
-        "subvariant": "Design_suite",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/i386/iso/Fedora-Games-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "5245603773fcc1c39a704f5a775019b3b422beb21158524613759552a84ed6f4",
-        "size": "4128243712",
-        "subvariant": "Games",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/i386/iso/Fedora-Jam_KDE-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "b4c74beecf82bb57703a4c6c49ec5169df1016c715bba163ce34dcf223ea4518",
-        "size": "2191523840",
-        "subvariant": "Jam_KDE",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/i386/iso/Fedora-Robotics-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "8caeeb28d802150ca674652480de24dc0d3296521c32a5e054df927a79199fe0",
-        "size": "2451570688",
-        "subvariant": "Robotics",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/i386/iso/Fedora-Scientific_KDE-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "d3c0040ba6492831ebed21b38c8b01afb1a80f94fe0dd2970c7be2bd09b91e13",
-        "size": "3158310912",
-        "subvariant": "Scientific_KDE",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Labs/i386/iso/Fedora-Security-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "95425cd633dc00de9fc8904820c7cc8fb0ddb42995a3b2936e52ed6a691d1e8b",
-        "size": "1241513984",
-        "subvariant": "Security",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "2eaf3c174a2020fa085c11e563ced85925a1fd66049de6d31bba5d655704d6ce",
-        "size": "500170752",
-        "subvariant": "Everything",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Everything/i386/iso/Fedora-Everything-netinst-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "f2f373e85d96e2164d38e26fe8ed7cf00abcf1edcf2704be69f2bdc1b851376a",
-        "size": "487587840",
-        "subvariant": "Everything",
-        "version": "25"
-    },
-    {
+## TODO Update to F26 Work-netinst.
+#    {
+#        "arch": "x86_64",
+#        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Workstation/x86_64/iso/Fedora-Workstation-netinst-x86_64-26-1.5.iso",
+#        "releaseDate": "2016-11-22",
+#        "sha256": "6a1e69416b0d72efd2962ce01bdad547074a32b70f7d70e2e6436d16398522a7",
+#        "size": "486539264",
+#        "subvariant": "Workstation",
+#        "version": "26"
+     },
+#    {
+#        "arch": "armhfp",
+#        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Workstation/armhfp/images/Fedora-Workstation-armhfp-25-1.3-sda.raw.xz",
+#        "releaseDate": "2016-11-22",
+#        "sha256": "553885d5643de06c468997f0e6a0bc1f1ba759d5ed806ac4d3f115522dfd6fbf",
+#        "size": "1253551936",
+#        "subvariant": "Workstation",
+#        "version": "25"
+#    },
+#    {
+#        "arch": "x86_64",
+#        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Cloud/x86_64/iso/Fedora-Cloud-netinst-x86_64-25-1.3.iso",
+#        "releaseDate": "2016-11-22",
+#        "sha256": "4d3413ed81e89baf79efa4c0217ad652967699b5072147ae3eeef7e075e3723d",
+#        #"size": "503316480",
+#        "subvariant": "Cloud",
+#        "version": "25"
+#    },
+#    {
+#        "arch": "x86_64",
+#        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Server/x86_64/iso/Fedora-Server-dvd-x86_64-26-1.5.iso",
+#        "releaseDate": "2016-11-22",
+#        "sha256": "524bd959dae09ad6fc8e0476ea478700d89f82ec5795d0b1a7b873613f3f26ac",
+#        "size": "2018508800",
+#        "subvariant": "Server",
+#        "version": "26"
+#    },
+#    {
+#        "arch": "x86_64",
+#        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Server/x86_64/iso/Fedora-Server-netinst-x86_64-25-1.3.iso",
+#        "releaseDate": "2016-11-22",
+#        "sha256": "86bc3694f4938382753d1e9536f2140a6c9c1978207766340c679a89509073c7",
+#        "size": "507510784",
+#        "subvariant": "Server",
+#       "version": "25"
+#    },
+#    {
+#        "arch": "x86_64",
+#        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-25-1.3.iso",
+#        "releaseDate": "2016-11-22",
+#        "sha256": "2eaf3c174a2020fa085c11e563ced85925a1fd66049de6d31bba5d655704d6ce",
+#        "size": "500170752",
+#        "subvariant": "Everything",
+#        "version": "25"
+#    },
+     {
         "arch": "x86_64",
         "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-25-1.3.x86_64.qcow2",
         "releaseDate": "2016-11-22",
@@ -341,15 +135,6 @@
         "releaseDate": "2016-11-22",
         "sha256": "0d1910416a63920b0c2d8398d37d9440e74283ba83ba442dc84047987f7d1165",
         "size": "41764492",
-        "subvariant": "Docker_Base",
-        "version": "25"
-    },
-    {
-        "arch": "armhfp",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Docker/armhfp/images/Fedora-Docker-Base-25-1.3.armhfp.tar.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "95df044b34edf5e0ffe5f5b4903b911e8a5f87b7909f4e2dadd3a279afb37f41",
-        "size": "37921920",
         "subvariant": "Docker_Base",
         "version": "25"
     },
@@ -407,356 +192,4 @@
         "subvariant": "Xfce",
         "version": "25"
     },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/i386/iso/Fedora-Cinnamon-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "6a57af008c8317fb64f34cad4116607347e5e24d9cf4981d72a6796da485202c",
-        "size": "1512046592",
-        "subvariant": "Cinnamon",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/i386/iso/Fedora-KDE-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "66af4a8aff80bb965130865f259e2c9f5e72f1657e3a7b7c317b4bb77b620a18",
-        "size": "1499463680",
-        "subvariant": "KDE",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/i386/iso/Fedora-LXDE-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "1f05300e60676ca3e68e2554bb506b4c0e1c30c824676aa7c11534646063fc0a",
-        "size": "1035993088",
-        "subvariant": "LXDE",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/i386/iso/Fedora-MATE_Compiz-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "ea97da880d22fc35c7ffe10ff6831ef16c772af8ec7dc7b511cfdcd7de652472",
-        "size": "1541406720",
-        "subvariant": "Mate",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/i386/iso/Fedora-SoaS-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "d396c02432045150992bd9c4ec4aff903a63186ee0cd80681afe9d81ef1d74a2",
-        "size": "816840704",
-        "subvariant": "SoaS",
-        "version": "25"
-    },
-    {
-        "arch": "i386",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/i386/iso/Fedora-Xfce-Live-i386-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "e7f2e56304dfb3b6153a93ca1bbea6cee5c4bd6aa51e726d32fa930b9e0767ab",
-        "size": "1207959552",
-        "subvariant": "Xfce",
-        "version": "25"
-    },
-    {
-        "arch": "armhfp",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/armhfp/images/Fedora-KDE-armhfp-25-1.3-sda.raw.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "619cc6e2e57d3d6d5a023039ed5a1b8046a98dffd91b74e9d13a5d590116513f",
-        "size": "1611001648",
-        "subvariant": "KDE",
-        "version": "25"
-    },
-    {
-        "arch": "armhfp",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/armhfp/images/Fedora-LXDE-armhfp-25-1.3-sda.raw.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "0c5e46da34310c7d458ee577a479c194ffc25c57345b6ccd884e844d8b44e286",
-        "size": "988942068",
-        "subvariant": "LXDE",
-        "version": "25"
-    },
-    {
-        "arch": "armhfp",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/armhfp/images/Fedora-Mate-armhfp-25-1.3-sda.raw.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "2d7b957668464aabaab0dbaf33f3959bbfcd938c6df2f23f1cf0a764485ebcfc",
-        "size": "1366250876",
-        "subvariant": "Mate",
-        "version": "25"
-    },
-    {
-        "arch": "armhfp",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/armhfp/images/Fedora-Minimal-armhfp-25-1.3-sda.raw.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "cb76ad8890683c0c4fb7b21c3491be258bf7418d1a638fbbfd9228872298a516",
-        "size": "475645772",
-        "subvariant": "Minimal",
-        "version": "25"
-    },
-    {
-        "arch": "armhfp",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/armhfp/images/Fedora-SoaS-armhfp-25-1.3-sda.raw.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "6a5e9736384a55fd89404337972fd561601b1cd968a62f93f8c087f51f04730d",
-        "size": "778904132",
-        "subvariant": "SoaS",
-        "version": "25"
-    },
-    {
-        "arch": "armhfp",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/armhfp/images/Fedora-Xfce-armhfp-25-1.3-sda.raw.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "bf03ca57693e6bc3cec41c8d925e7376876e44d8b5c511cea1ce4a7ba194d595",
-        "size": "1085579848",
-        "subvariant": "Xfce",
-        "version": "25"
-    },
-    {
-        "subvariant": "workstation",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-24-1.2.iso",
-        "sha256": "8e12d7ba1fcf3328b8514d627788ee0146c0eef75a5e27f0674ee1fe4f1feaf6",
-        "size": "1503238553",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "workstation",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Workstation/i386/iso/Fedora-Workstation-Live-i386-24-1.2.iso",
-        "sha256": "1c96e1529cb25b08dac4ef29cb4f6eafdd9b6bbf008642fb4ae01a5e9bb31255",
-        "size": "1717986918",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "server",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Server/x86_64/iso/Fedora-Server-dvd-x86_64-24-1.2.iso",
-        "sha256": "1c0971d4c1a37bb06ec603ed3ded0af79e22069499443bb2d47e501c9ef42ae8",
-        "size": "1825361100",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "kde",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Spins/x86_64/iso/Fedora-KDE-Live-x86_64-24-1.2.iso",
-        "sha256": "28bcde6e4c2e5471ef982fcf15930fbc4181ccf4bd47efad8f915c7d89c29bbb",
-        "size": "1288490188",
-        "arch": "x86_64"
-    },
-
-    {
-        "subvariant": "kde",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Spins/i386/iso/Fedora-KDE-Live-i386-24-1.2.iso",
-        "sha256": "70a1833b2bbc8309acef36b354384412b12c05bde6aa1e5a1403febe652b50ab",
-        "size": "1288490188",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "xfce",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Spins/x86_64/iso/Fedora-Xfce-Live-x86_64-24-1.2.iso",
-        "sha256": "71a1ab11cf92660bd8508ed14248e8341abac99002c7c3db71f4403e32bb6a9c",
-        "size": "960495616",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "xfce",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Spins/i386/iso/Fedora-Xfce-Live-i386-24-1.2.iso",
-        "sha256": "8837a634a65db89a42344213aa83f6fe251d4df30e02ca8826c5ded183a7b9f1",
-        "size": "934281216",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "lxde",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Spins/x86_64/iso/Fedora-LXDE-Live-x86_64-24-1.2.iso",
-        "sha256": "74400c0b08adadb249b224466468b3b50e72157abf266d845137f3988fe407ad",
-        "size": "877658112",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "lxde",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Spins/i386/iso/Fedora-LXDE-Live-i386-24-1.2.iso",
-        "sha256": "ab497657c6a9108373415f43e052e9a0aa80e449627a385bda63345818651e52",
-        "size": "1010827264",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "mate",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Spins/x86_64/iso/Fedora-MATE_Compiz-Live-x86_64-24-1.2.iso",
-        "sha256": "0ad0b5c2ac188330de7f3614781ce5480e1214bd64d08821cfef23030128876f",
-        "size": "1395864371",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "mate",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Spins/i386/iso/Fedora-MATE_Compiz-Live-i386-24-1.2.iso",
-        "sha256": "1e350f8a2e5509cd53d3ecade36d5df260830e59e924535c130f15b06ea578b9",
-        "size": "1288490188",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "cinnamon",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Spins/x86_64/iso/Fedora-Cinnamon-Live-x86_64-24-1.2.iso",
-        "sha256": "df601acd9eebc21ba2a5a1949db072d34f1a04fd762da1dca0299a59bf97a0f8",
-        "size": "1288490188",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "cinnamon",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/24/Spins/i386/iso/Fedora-Cinnamon-Live-i386-24-1.2.iso",
-        "sha256": "7912efc41e75bf79c35c6bbd5b072dd456b4836cae0fc69ac24890bfaccbe9b7",
-        "size": "1288490188",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "soas",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://dl.fedoraproject.org/pub/alt/unofficial/releases/24/x86_64/Fedora-SoaS-Live-x86_64-24-20160614.n.0.iso",
-        "sha256": "ba1dbd4bac36660f8f5b6ef9acaa18bcfb117413bc2b557b05a876778f4fa777",
-        "size": "732954624",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "soas",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://dl.fedoraproject.org/pub/alt/unofficial/releases/24/i386/Fedora-SoaS-Live-i386-24-20160614.n.0.iso",
-        "sha256": "2af7c621681c3f4978e71a25bfd608fa66d2b441db51806b9ab639901c8eec58",
-        "size": "708837376",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "astronomy",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/24/Labs/x86_64/iso/Fedora-Astronomy_KDE-Live-x86_64-24-1.2.iso",
-        "sha256": "eeb21b6801494668d2031a0c341cfd266b633ae33d7ce5cd3ea1ec308e70224a",
-        "size": "2477785088",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "astronomy",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/24/Labs/i386/iso/Fedora-Astronomy_KDE-Live-i386-24-1.2.iso",
-        "sha256": "e5724016044f1f0b836d8551a10ae6e0b987552e1fa934e58d0aca3a61ab185d",
-        "size": "2631925760",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "design",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://dl.fedoraproject.org/pub/alt/unofficial/releases/24/x86_64/Fedora-Design_suite-Live-x86_64-24-20160614.n.0.iso",
-        "sha256": "d9a44a18e7433e8d523fa38d7c0f71199b5866af57d17f3c1e433cdd098373cd",
-        "size": "1932735283",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "design",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://dl.fedoraproject.org/pub/alt/unofficial/releases/24/i386/Fedora-Design_suite-Live-i386-24-20160614.n.0.iso",
-        "sha256": "77ac8c0ec235604ea2a49ad475356d243636f460410038879504fc82665c1651",
-        "size": "2040109465",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "games",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/24/Labs/x86_64/iso/Fedora-Games-Live-x86_64-24-1.2.iso",
-        "sha256": "84ebef0dfc7a15af5164ed8c40f8bd7ea4fbdf8046457f3fe7e6278d2fcd5510",
-        "size": "3865470566",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "games",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/24/Labs/i386/iso/Fedora-Games-Live-i386-24-1.2.iso",
-        "sha256": "a9cefe5d295ac9a0bfb61185917694fa81b2ca51bf0b547b8d8ecf892b191a25",
-        "size": "4080218931",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "robotics",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/24/Labs/x86_64/iso/Fedora-Robotics-Live-x86_64-24-1.2.iso",
-        "sha256": "fd5a0718f85499d0fe69f9c9a8fcf00eb32ec06e8b7520ddd063433a462ce6b7",
-        "size": "2576980377",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "robotics",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/24/Labs/i386/iso/Fedora-Robotics-Live-i386-24-1.2.iso",
-        "sha256": "1e689c0b67def88d4a94e600c559f2e30fa92a10a6669081d87117227327702e",
-        "size": "2899102924",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "scientific",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/24/Labs/x86_64/iso/Fedora-Scientific_KDE-Live-x86_64-24-1.2.iso",
-        "sha256": "6cfdba696cbd69e2878f4c6f4ee5cf7852dc6b6265ddf85477c48e67822d0aeb",
-        "size": "3113851289",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "scientific",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/24/Labs/i386/iso/Fedora-Scientific_KDE-Live-i386-24-1.2.iso",
-        "sha256": "68536eafea38c6c83303355f897eea4034c01b1c28d8ffd3e3ccfc5f51983307",
-        "size": "3435973836",
-        "arch": "i386"
-    },
-    {
-        "subvariant": "security",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/24/Labs/x86_64/iso/Fedora-Security-Live-x86_64-24-1.2.iso",
-        "sha256": "522b432295b380afcaf91310672e34f23a3b2219f0209b7d3cc6d99d03959807",
-        "size": "1181116006",
-        "arch": "x86_64"
-    },
-    {
-        "subvariant": "security",
-        "version": "24",
-        "releaseDate": "2016-06-21",
-        "link": "https://download.fedoraproject.org/pub/alt/releases/24/Labs/i386/iso/Fedora-Security-Live-i386-24-1.2.iso",
-        "sha256": "5e66b08452932735009e053ea094fb19a423ac33934294bd6be19087154d2a4f",
-        "size": "1288490188",
-        "arch": "i386"
-    }
 ]

--- a/src/data/releases.json
+++ b/src/data/releases.json
@@ -1,56 +1,86 @@
 [
+## "TODO": "Update SHA256|512sums, GA releaseDate, size values",
     {
-        "arch": "x86_64",
-        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-WORK-x86_64-20170927.iso",
-        "subvariant": "WORK-latest",
+	"arch": "x86_64",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-WORK-x86_64-20171005.iso",
+        "releaseDate": "20171005",
+	"sha512": :"",
+	"size":"",
+	"subvariant": "WORK-latest",
         "version": "26"
     },
     {
         "arch": "x86_64",
         "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Server/x86_64/iso/Fedora-Server-dvd-x86_64-26-1.5.iso",
-        "subvariant": "Server",
+        "releaseDate": "",
+	"sha512": "",
+	"size":" ",
+	"subvariant": "Server-traditional",
         "version": "26"
     },
     {
         "arch": "x86_64",
         "link": "https://download.fedoraproject.org/pub/alt/releases/26/Labs/x86_64/iso/Fedora-Python-Classroom-Live-x86_64-26-1.5.iso",
-        "subvariant": "python-classroom",
+        "releaseDate": "",
+	"sha512": "",
+	"size": "",
+	"subvariant": "python-classroom",
         "version": "26"
     },
     {
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-KDE-x86_64-20170927.iso",
-        "subvariant": "KDE-latest",
-        "version": "26"
+        "releaseDate": "20170927",
+	"sha512": "",
+	"size":"",
+	"subvariant": "KDE-latest",
+        "version": "26",
+	"note":"Failed to build 20171005"
     },
     {
         "arch": "x86_64",
-        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-XFCE-x86_64-20170927.iso",
-        "subvariant": "XFCE-latest",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-XFCE-x86_64-20171005.iso",
+        "releaseDate": "",
+	"sha512": "",
+	"size": "",
+	"subvariant": "XFCE-latest",
         "version": "26"
     },
     {
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-MATE-x86_64-20170927.iso",
-        "subvariant": "MATE-latest",
-        "version": "26"
+        "releaseDate": "",
+	"sha512": "",
+	"size":"",
+	"subvariant": "MATE-latest",
+        "version": "26",
+	"note": "Failed to build 20171005"
     },
     {
         "arch": "x86_64",
-        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-LXDE-x86_64-20170927.iso",
-        "subvariant": "LXDE-latest",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-LXDE-x86_64-20171005.iso",
+        "releaseDate": "20171005".
+	"sha512":"",
+	"size":"",
+	"subvariant": "LXDE-latest",
         "version": "26"
      },
     {
-        "arch": "armhfp",
-        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-LXQT-x86_64-20170927.iso",
-       	"subvariant": "LXQT-latest",
+        "arch": "x86_64",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-LXQT-x86_64-20171005.iso",
+       	"releaseDate": "20171005",
+	"sha512": "",
+	"size":"",
+	"subvariant": "LXQT-latest",
         "version": "26"
     },
     {
         "arch": "x86_64",
-        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-CINN-x86_64-20170927.iso",
-        "subvariant": "CINN-latest",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-CINN-x86_64-20171005.iso",
+        "releaseDate": "20171005",
+        "sha512": "",
+	"size": "",
+	"subvariant": "CINN-latest",
         "version": "26"
     },
     {
@@ -59,55 +89,65 @@
         "releaseDate": "2016-11-22",
         "sha256": "524bd959dae09ad6fc8e0476ea478700d89f82ec5795d0b1a7b873613f3f26ac",
         "size": "2018508800",
-        "subvariant": "Server",
+        "subvariant": "Server-DVD",
         "version": "26"
     },
     {
         "arch": "x86_64",
         "link": "https://dl.fedoraproject.org/pub/alt/releases/26/Labs/x86_64/iso/Fedora-Astronomy_KDE-Live-x86_64-26-1.5.iso",
-        "subvariant": "Astronomy",
+        "releaseDate": "",
+	"sha256": "" ,
+	"size": "",
+	"subvariant": "Astronomy",
         "version": "26"
     },
     {
+## "TODO":"Update for KDE_JAM",
 	"arch": "x86_64", 
-	"link":"/download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/x86_64/iso/Fedora-KDE-Live-x86_64-25-1.3.iso",
-	"subvariant": "KDE",
-        "version": "25"
+	"link":"",
+	"releaseDate":"",
+	"sha256":"",
+	"size":"",
+	"subvariant": "KDE-Jam",
+        "version": "26"
+    },
+    {
+## "TODO":"Update for Security Spin",
+        "arch": "x86_64",
+        "link": "",
+        "releaseDate": "",
+        "sha256": "",
+        "size": "",
+        "subvariant": "SecurityLab",
+        "version": "26"
+    },
+    {
+## "TODO":"Update for Design_Suite",
+        "arch": "x86_64",
+        "link": "",
+        "releaseDate": "",
+        "sha256": "",
+        "size": "",
+        "subvariant": "Design_Suite",
+        "version": "26"
     },
     {
         "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/x86_64/iso/Fedora-LXDE-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "03a59d2970f085bcb8863ac1d146953d4001b2e72f11f6d5a3639e3fd5dda66b",
-        "size": "955252736",
-        "subvariant": "LXDE",
-        "version": "25"
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-SOAS-x86_64-20171005.iso",
+        "releaseDate": "20171005",
+        "sha256": "",
+        "size": "",
+        "subvariant": "SOAS",
+        "version": "26"
     },
     {
+## "TODO":"Update for Scientific_KDE",
         "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/x86_64/iso/Fedora-MATE_Compiz-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "d7ac7b9ce246d1cd6d4f3c1bf3a0981708babfbaf7682b718ea09066854c9442",
-        "size": "1453326336",
-        "subvariant": "Mate",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/x86_64/iso/Fedora-SoaS-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "4ba966923dbab7c4deeb28c5781e6bba51fe8d85007d75fc6ba946da2b93512f",
-        "size": "734003200",
-        "subvariant": "SoaS",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/x86_64/iso/Fedora-Xfce-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "b92bea94a1a14ff4a617f7571c184564d79649033f1c98950bc4a1a80ee70c58",
-        "size": "1124073472",
-        "subvariant": "Xfce",
-        "version": "25"
+        "link": "",
+        "releaseDate": "",
+        "sha256": "",
+        "size": "",
+	"subvariant": "Scientific_KDE",
+        "version": "26"
     },
 ]

--- a/src/data/releases.json
+++ b/src/data/releases.json
@@ -4,7 +4,7 @@
 	"arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-WORK-x86_64-20171005.iso",
         "releaseDate": "20171005",
-	"sha512": :"",
+	"sha512": :"af22e38f3ce74dda3fc4a784e2bb3a19179ea2413de18d4e16f2a6f9e4d2781c27191693ec22ad206d35dd7688d704e2c8557519bea1e2b6f85a5f956f504855",
 	"size":"",
 	"subvariant": "WORK-latest",
         "version": "26"
@@ -13,7 +13,7 @@
         "arch": "x86_64",
         "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Server/x86_64/iso/Fedora-Server-dvd-x86_64-26-1.5.iso",
         "releaseDate": "",
-	"sha512": "",
+	"sha256": "",
 	"size":" ",
 	"subvariant": "Server-traditional",
         "version": "26"
@@ -22,7 +22,7 @@
         "arch": "x86_64",
         "link": "https://download.fedoraproject.org/pub/alt/releases/26/Labs/x86_64/iso/Fedora-Python-Classroom-Live-x86_64-26-1.5.iso",
         "releaseDate": "",
-	"sha512": "",
+	"sha256": "",
 	"size": "",
 	"subvariant": "python-classroom",
         "version": "26"
@@ -31,7 +31,7 @@
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-KDE-x86_64-20170927.iso",
         "releaseDate": "20170927",
-	"sha512": "",
+	"sha512": "d2ba1dd9960fddb950da54756df2f4744d884bb88af26066c0456b5d2a080e8eb415868e82a78533ba8aa165b726d321738fca3164fd7dc8c690b06b315865d3",
 	"size":"",
 	"subvariant": "KDE-latest",
         "version": "26",
@@ -41,7 +41,7 @@
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-XFCE-x86_64-20171005.iso",
         "releaseDate": "",
-	"sha512": "",
+	"sha512": "00b23af417ec1892a9d48a32dbfd12b848dfcbf1888636f849ec6a2ce419417d2a0337e8048885253a8dc12bd456e41aeb8bd28dede9c9ff60b12c4e40871415",
 	"size": "",
 	"subvariant": "XFCE-latest",
         "version": "26"
@@ -50,7 +50,7 @@
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-MATE-x86_64-20170927.iso",
         "releaseDate": "",
-	"sha512": "",
+	"sha512": "91c24c654ba202ed7d22a057ea088d50a31752f1500a30806897a2ed705ac476e472c81f05f7c72f9e47b3671eebda0743d958bcbab6d8a612324b1b893e6580",
 	"size":"",
 	"subvariant": "MATE-latest",
         "version": "26",
@@ -60,7 +60,7 @@
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-LXDE-x86_64-20171005.iso",
         "releaseDate": "20171005".
-	"sha512":"",
+	"sha512":"687f9d07fc7a6af79c9a796c283bea2367b2d0fbdfd1521144a1272a2c650f6382ddbaff979412621693e662e24cd82bf68b34370e04f718b5c52c9e6922907b",
 	"size":"",
 	"subvariant": "LXDE-latest",
         "version": "26"
@@ -70,7 +70,7 @@
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-LXQT-x86_64-20171005.iso",
        	"releaseDate": "20171005",
 	"sha512": "",
-	"size":"",
+	"size":"930a2ccadc839fbc649d6115c577c4f106c0c8dc515dbc431c10431d538e591ae0f1ec1b980e9248469b9025954ef591f86e55d14959fd4b06cf174aabb69a0c",
 	"subvariant": "LXQT-latest",
         "version": "26"
     },
@@ -78,7 +78,7 @@
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-CINN-x86_64-20171005.iso",
         "releaseDate": "20171005",
-        "sha512": "",
+        "sha512": "da82ecf0b9466ecb1392f341182359872c46a95064df921110eac06a0e507c4b1ef6e554d6b0585a097511bbe964f5a966c5227e7981fddec8bc55958cf4e2e9",
 	"size": "",
 	"subvariant": "CINN-latest",
         "version": "26"

--- a/src/data/releases.json
+++ b/src/data/releases.json
@@ -2,7 +2,7 @@
     {
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-WORK-x86_64-20170927.iso",
-        "subvariant": "Workstation",
+        "subvariant": "WORK-latest",
         "version": "26"
     },
     {
@@ -20,140 +20,58 @@
     {
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-KDE-x86_64-20170927.iso",
-        "subvariant": "KDE",
+        "subvariant": "KDE-latest",
         "version": "26"
     },
     {
         "arch": "x86_64",
         "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-XFCE-x86_64-20170927.iso",
-        "subvariant": "XFCE",
+        "subvariant": "XFCE-latest",
         "version": "26"
     },
     {
         "arch": "x86_64",
-        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-WORK-x86_64-20170927.iso",
-        "releaseDate": "2017-09-29",
-        "sha512": "c7ce66fb93abbf4987e71bb4b7783dffb696098af539c588594e8952ff251a653895936621ffa615211ca693a89d493bc7622e9ce65c18da4b4cf2c1f34feb56",
-        "size": "1500512256",
-        "subvariant": "Workstation",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-MATE-x86_64-20170927.iso",
+        "subvariant": "MATE-latest",
         "version": "26"
     },
-## TODO Update to F26 Work-netinst.
-#    {
-#        "arch": "x86_64",
-#        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Workstation/x86_64/iso/Fedora-Workstation-netinst-x86_64-26-1.5.iso",
-#        "releaseDate": "2016-11-22",
-#        "sha256": "6a1e69416b0d72efd2962ce01bdad547074a32b70f7d70e2e6436d16398522a7",
-#        "size": "486539264",
-#        "subvariant": "Workstation",
-#        "version": "26"
+    {
+        "arch": "x86_64",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-LXDE-x86_64-20170927.iso",
+        "subvariant": "LXDE-latest",
+        "version": "26"
      },
-#    {
-#        "arch": "armhfp",
-#        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Workstation/armhfp/images/Fedora-Workstation-armhfp-25-1.3-sda.raw.xz",
-#        "releaseDate": "2016-11-22",
-#        "sha256": "553885d5643de06c468997f0e6a0bc1f1ba759d5ed806ac4d3f115522dfd6fbf",
-#        "size": "1253551936",
-#        "subvariant": "Workstation",
-#        "version": "25"
-#    },
-#    {
-#        "arch": "x86_64",
-#        "link": "https://download.fedoraproject.org/pub/alt/releases/25/Cloud/x86_64/iso/Fedora-Cloud-netinst-x86_64-25-1.3.iso",
-#        "releaseDate": "2016-11-22",
-#        "sha256": "4d3413ed81e89baf79efa4c0217ad652967699b5072147ae3eeef7e075e3723d",
-#        #"size": "503316480",
-#        "subvariant": "Cloud",
-#        "version": "25"
-#    },
-#    {
-#        "arch": "x86_64",
-#        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Server/x86_64/iso/Fedora-Server-dvd-x86_64-26-1.5.iso",
-#        "releaseDate": "2016-11-22",
-#        "sha256": "524bd959dae09ad6fc8e0476ea478700d89f82ec5795d0b1a7b873613f3f26ac",
-#        "size": "2018508800",
-#        "subvariant": "Server",
-#        "version": "26"
-#    },
-#    {
-#        "arch": "x86_64",
-#        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Server/x86_64/iso/Fedora-Server-netinst-x86_64-25-1.3.iso",
-#        "releaseDate": "2016-11-22",
-#        "sha256": "86bc3694f4938382753d1e9536f2140a6c9c1978207766340c679a89509073c7",
-#        "size": "507510784",
-#        "subvariant": "Server",
-#       "version": "25"
-#    },
-#    {
-#        "arch": "x86_64",
-#        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-25-1.3.iso",
-#        "releaseDate": "2016-11-22",
-#        "sha256": "2eaf3c174a2020fa085c11e563ced85925a1fd66049de6d31bba5d655704d6ce",
-#        "size": "500170752",
-#        "subvariant": "Everything",
-#        "version": "25"
-#    },
-     {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-25-1.3.x86_64.qcow2",
-        "releaseDate": "2016-11-22",
-        "sha256": "4942be57a97c7e6f9f420ba29555776c79ed49c603d7cabb0394bb1a790eb336",
-        "size": "196662784",
-        "subvariant": "Cloud_Base",
-        "version": "25"
+    {
+        "arch": "armhfp",
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-LXQT-x86_64-20170927.iso",
+       	"subvariant": "LXQT-latest",
+        "version": "26"
     },
     {
         "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-25-1.3.x86_64.raw.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "01c8a1087f3621365939ecec7bfc8a5a57289a1443eff391a06ab39656e65739",
-        "size": "128638192",
-        "subvariant": "Cloud_Base",
-        "version": "25"
+        "link": "https://alt.fedoraproject.org/pub/alt/live-respins/F26-CINN-x86_64-20170927.iso",
+        "subvariant": "CINN-latest",
+        "version": "26"
     },
     {
         "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-25-1.3.x86_64.vagrant-libvirt.box",
+        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/26/Server/x86_64/iso/Fedora-Server-dvd-x86_64-26-1.5.iso",
         "releaseDate": "2016-11-22",
-        "sha256": "148a4c3744f7b4de24e745541e94d9aadfd0e0a22069065b607c94ec8e493db6",
-        "size": "208633544",
-        "subvariant": "Cloud_Base",
-        "version": "25"
+        "sha256": "524bd959dae09ad6fc8e0476ea478700d89f82ec5795d0b1a7b873613f3f26ac",
+        "size": "2018508800",
+        "subvariant": "Server",
+        "version": "26"
     },
     {
         "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-25-1.3.x86_64.vagrant-virtualbox.box",
-        "releaseDate": "2016-11-22",
-        "sha256": "390addeab171fadec4d5901e9eb2054bd955efeebc6a8b2231c7881803245d38",
-        "size": "217845760",
-        "subvariant": "Cloud_Base",
-        "version": "25"
+        "link": "https://dl.fedoraproject.org/pub/alt/releases/26/Labs/x86_64/iso/Fedora-Astronomy_KDE-Live-x86_64-26-1.5.iso",
+        "subvariant": "Astronomy",
+        "version": "26"
     },
     {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Docker/x86_64/images/Fedora-Docker-Base-25-1.3.x86_64.tar.xz",
-        "releaseDate": "2016-11-22",
-        "sha256": "0d1910416a63920b0c2d8398d37d9440e74283ba83ba442dc84047987f7d1165",
-        "size": "41764492",
-        "subvariant": "Docker_Base",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/x86_64/iso/Fedora-Cinnamon-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "7d859d84fbd036da772a8ab3e4c1731e4aef5051ef37acb38f9df4209237390e",
-        "size": "1422917632",
-        "subvariant": "Cinnamon",
-        "version": "25"
-    },
-    {
-        "arch": "x86_64",
-        "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/x86_64/iso/Fedora-KDE-Live-x86_64-25-1.3.iso",
-        "releaseDate": "2016-11-22",
-        "sha256": "2345e79043a36980c535f74ef63613f9dd22f4ecb8ccdf3df5cb5199ca4c75b7",
-        "size": "1389363200",
-        "subvariant": "KDE",
+	"arch": "x86_64", 
+	"link":"/download.fedoraproject.org/pub/fedora/linux/releases/25/Spins/x86_64/iso/Fedora-KDE-Live-x86_64-25-1.3.iso",
+	"subvariant": "KDE",
         "version": "25"
     },
     {


### PR DESCRIPTION
Removed all EoL references (F23,F24,25)
Updated to point all the Desktop Spins (CINN,KDE,LXDE,LXQT,MATE,SOAS,WORK,XFCE) to use the present updated lives ( the $date field will need to be variable-ized or manually updated to the newest -latest in the future, however the new stub path is set.

Updated Spins/Labs to use the present suite of ISOs presently available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sanqui/fedorator/16)
<!-- Reviewable:end -->
